### PR TITLE
Enhancement: compute the correlation between two matches instead of only counting the matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ bin/*
 
 # Ignore dataset by default
 assets/dataset/*
+
+.idea/

--- a/cmd/musig/cmd/listen.go
+++ b/cmd/musig/cmd/listen.go
@@ -24,5 +24,6 @@ var listenCmd = &cobra.Command{
 
 		recordAudioToFile(name, dur)
 		cmdRead(name)
+		// todo remove
 	},
 }

--- a/cmd/musig/cmd/listen.go
+++ b/cmd/musig/cmd/listen.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	log "github.com/sirupsen/logrus"
 	"os"
 	"path"
 	"time"
@@ -22,8 +23,13 @@ var listenCmd = &cobra.Command{
 		dur, err := cmd.Flags().GetDuration("duration")
 		failIff(err, "could not get duration, got: %v", dur)
 
+		defer func() {
+			if err := os.Remove(name); err != nil {
+				log.Errorf("Failed to remove temporary file stored at %s used to record the sample: %s", name , err)
+			}
+		}()
+
 		recordAudioToFile(name, dur)
 		cmdRead(name)
-		// todo remove
 	},
 }

--- a/cmd/musig/cmd/listen.go
+++ b/cmd/musig/cmd/listen.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
-	"os/signal"
+	"path"
 	"time"
 
-	"github.com/sfluor/musig/internal/pkg/sound"
 	"github.com/spf13/cobra"
 )
 
@@ -20,33 +18,11 @@ var listenCmd = &cobra.Command{
 	Use:   "listen",
 	Short: "listen will record the microphone input and try to find a matching song from the database (Ctrl-C will stop the recording)",
 	Run: func(cmd *cobra.Command, args []string) {
-		tmpFile, err := ioutil.TempFile(os.TempDir(), "musig_record.wav")
-		failIff(err, "error creating temporary file for recording in %s", tmpFile.Name())
-		defer os.Remove(tmpFile.Name())
-
-		stopCh := make(chan struct{}, 1)
-		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, os.Interrupt, os.Kill)
-
+		name := path.Join(os.TempDir(), "musig_record.wav")
 		dur, err := cmd.Flags().GetDuration("duration")
 		failIff(err, "could not get duration, got: %v", dur)
 
-		go func() {
-			defer func() { stopCh <- struct{}{} }()
-			for {
-				select {
-				case <-time.After(dur):
-					return
-				case <-sig:
-					return
-				}
-			}
-		}()
-
-		err = sound.RecordWAV(tmpFile, stopCh)
-		failIff(err, "an error occured recording WAV file")
-		failIff(tmpFile.Sync(), "error syncing temp file")
-
-		cmdRead(tmpFile.Name())
+		recordAudioToFile(name, dur)
+		cmdRead(name)
 	},
 }

--- a/cmd/musig/cmd/load.go
+++ b/cmd/musig/cmd/load.go
@@ -12,6 +12,7 @@ import (
 func init() {
 	rootCmd.AddCommand(loadCmd)
 	loadCmd.Flags().BoolP("dry-run", "d", false, "disable saving to the database")
+	loadCmd.Flags().BoolP("reset", "r", false, "reset the database if it already exists")
 	loadCmd.Flags().BoolP("verbose", "v", false, "enable verbose output")
 }
 
@@ -27,6 +28,14 @@ var loadCmd = &cobra.Command{
 		if files == nil {
 			log.Infof("no files matched pattern: %s", args[0])
 			os.Exit(0)
+		}
+
+		resetDB, err := cmd.Flags().GetBool("reset")
+		if resetDB && err == nil {
+			log.Info("removing the existing database...")
+			if err := os.Remove(dbFile); err != nil {
+				log.Errorf("Error removing the database at %s: %s", dbFile, err)
+			}
 		}
 
 		p, err := pipeline.NewDefaultPipeline(dbFile)

--- a/cmd/musig/cmd/read.go
+++ b/cmd/musig/cmd/read.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/sfluor/musig/internal/pkg/model"
 	"github.com/sfluor/musig/internal/pkg/pipeline"
+	"github.com/sfluor/musig/pkg/stats"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +21,19 @@ var readCmd = &cobra.Command{
 	},
 }
 
+// TODO move this outside
+func correlation(sample, match map[model.EncodedKey]model.TableValue) float64 {
+	// Will hold a list of points (time in the sample sound file, time in the matched database sound file)
+	points := [2][]float64{}
+	for k, sampleValue := range sample {
+		if matchValue, ok := match[k]; ok {
+			points[0] = append(points[0], float64(sampleValue.AnchorTimeMs))
+			points[1] = append(points[1], float64(matchValue.AnchorTimeMs))
+		}
+	}
+	return stats.Correlation(points[0], points[1])
+}
+
 func cmdRead(file string) {
 	p, err := pipeline.NewDefaultPipeline(dbFile)
 	failIff(err, "error creating pipeline")
@@ -29,19 +42,35 @@ func cmdRead(file string) {
 	res, err := p.Process(file)
 	failIff(err, "error processing file %s", file)
 
-	// Will hold a count of songID => occurences
+	// Will hold a count of songID => occurrences
 	counts := map[uint32]int{}
 	keys := make([]model.EncodedKey, 0, len(res.Fingerprint))
+	sample := map[model.EncodedKey]model.TableValue{}
+	// songID => points that matched
+	matches := map[uint32]map[model.EncodedKey]model.TableValue{}
 
-	for k := range res.Fingerprint {
+	for k, v := range res.Fingerprint {
 		keys = append(keys, k)
+		sample[k] = v
 	}
 
 	m, err := p.DB.Get(keys)
-	for _, values := range m {
+	for key, values := range m {
 		for _, val := range values {
 			counts[val.SongID] += 1
+
+			if _, ok := matches[val.SongID]; !ok {
+				matches[val.SongID] = map[model.EncodedKey]model.TableValue{}
+			}
+
+			matches[val.SongID][key] = val
 		}
+	}
+
+	// songID => correlation
+	correlations := map[uint32]float64{}
+	for songID, points := range matches {
+		correlations[songID] = correlation(sample, points)
 	}
 
 	var song string
@@ -50,7 +79,7 @@ func cmdRead(file string) {
 	for id, count := range counts {
 		name, err := p.DB.GetSong(id)
 		failIff(err, "error getting song id: %d", id)
-		fmt.Printf("\t- %s, count: %d\n", name, count)
+		fmt.Printf("\t- %s, count: %d, correlation: %f\n", name, count, correlations[id])
 		if count > max {
 			song, max = name, count
 		}

--- a/cmd/musig/cmd/read.go
+++ b/cmd/musig/cmd/read.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/sfluor/musig/internal/pkg/model"
 	"github.com/sfluor/musig/internal/pkg/pipeline"
-	"github.com/sfluor/musig/pkg/stats"
+	"github.com/sfluor/musig/pkg/dsp"
 	"github.com/spf13/cobra"
 )
 
@@ -21,19 +21,6 @@ var readCmd = &cobra.Command{
 	},
 }
 
-// TODO move this outside
-func correlation(sample, match map[model.EncodedKey]model.TableValue) float64 {
-	// Will hold a list of points (time in the sample sound file, time in the matched database sound file)
-	points := [2][]float64{}
-	for k, sampleValue := range sample {
-		if matchValue, ok := match[k]; ok {
-			points[0] = append(points[0], float64(sampleValue.AnchorTimeMs))
-			points[1] = append(points[1], float64(matchValue.AnchorTimeMs))
-		}
-	}
-	return stats.Correlation(points[0], points[1])
-}
-
 func cmdRead(file string) {
 	p, err := pipeline.NewDefaultPipeline(dbFile)
 	failIff(err, "error creating pipeline")
@@ -43,7 +30,6 @@ func cmdRead(file string) {
 	failIff(err, "error processing file %s", file)
 
 	// Will hold a count of songID => occurrences
-	counts := map[uint32]int{}
 	keys := make([]model.EncodedKey, 0, len(res.Fingerprint))
 	sample := map[model.EncodedKey]model.TableValue{}
 	// songID => points that matched
@@ -57,7 +43,6 @@ func cmdRead(file string) {
 	m, err := p.DB.Get(keys)
 	for key, values := range m {
 		for _, val := range values {
-			counts[val.SongID] += 1
 
 			if _, ok := matches[val.SongID]; !ok {
 				matches[val.SongID] = map[model.EncodedKey]model.TableValue{}
@@ -68,24 +53,23 @@ func cmdRead(file string) {
 	}
 
 	// songID => correlation
-	correlations := map[uint32]float64{}
+	scores := map[uint32]float64{}
 	for songID, points := range matches {
-		correlations[songID] = correlation(sample, points)
+		scores[songID] = dsp.MatchScore(sample, points)
 	}
 
 	var song string
-	var max, total int
+	var max float64
 	fmt.Println("Matches:")
-	for id, count := range counts {
+	for id, score := range scores {
 		name, err := p.DB.GetSong(id)
 		failIff(err, "error getting song id: %d", id)
-		fmt.Printf("\t- %s, count: %d, correlation: %f\n", name, count, correlations[id])
-		if count > max {
-			song, max = name, count
+		fmt.Printf("\t- %s, score: %f\n", name, score)
+		if score > max {
+			song, max = name, score
 		}
-		total += count
 	}
 
 	fmt.Println("---")
-	fmt.Printf("Song is: %s (count: %d, pct: %.2f %%)\n", song, max, 100*float64(max)/float64(total))
+	fmt.Printf("Song is: %s (score: %f)\n", song, max)
 }

--- a/cmd/musig/cmd/record.go
+++ b/cmd/musig/cmd/record.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/sfluor/musig/internal/pkg/sound"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(recordCmd)
+	recordCmd.Flags().DurationP("duration", "d", 10*time.Second, "duration of the listening")
+}
+
+// recordCmd represents the listen command
+var recordCmd = &cobra.Command{
+	Use:   "record",
+	Short: "record will record the microphone input and save the signal to the given file",
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		dur, err := cmd.Flags().GetDuration("duration")
+		failIff(err, "could not get duration, got: %v", dur)
+
+		recordAudioToFile(args[0], dur)
+	},
+}
+
+func recordAudioToFile(name string, duration time.Duration) {
+	file ,err := os.Create(name)
+	failIff(err, "error creating file for recording in %s", name)
+
+	stopCh := make(chan struct{}, 1)
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, os.Kill)
+
+	go func() {
+		defer func() { stopCh <- struct{}{} }()
+		for {
+			select {
+			case <-time.After(duration):
+				return
+			case <-sig:
+				return
+			}
+		}
+	}()
+
+	err = sound.RecordWAV(file, stopCh)
+	failIff(err, "an error occured recording WAV file")
+	failIff(file.Sync(), "error syncing temp file")
+}

--- a/cmd/musig/cmd/record.go
+++ b/cmd/musig/cmd/record.go
@@ -18,7 +18,7 @@ func init() {
 var recordCmd = &cobra.Command{
 	Use:   "record",
 	Short: "record will record the microphone input and save the signal to the given file",
-	Args: cobra.MinimumNArgs(1),
+	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		dur, err := cmd.Flags().GetDuration("duration")
 		failIff(err, "could not get duration, got: %v", dur)
@@ -28,7 +28,7 @@ var recordCmd = &cobra.Command{
 }
 
 func recordAudioToFile(name string, duration time.Duration) {
-	file ,err := os.Create(name)
+	file, err := os.Create(name)
 	failIff(err, "error creating file for recording in %s", name)
 
 	stopCh := make(chan struct{}, 1)
@@ -36,7 +36,9 @@ func recordAudioToFile(name string, duration time.Duration) {
 	signal.Notify(sig, os.Interrupt, os.Kill)
 
 	go func() {
-		defer func() { stopCh <- struct{}{} }()
+		defer func() {
+			stopCh <- struct{}{}
+		}()
 		for {
 			select {
 			case <-time.After(duration):
@@ -48,6 +50,6 @@ func recordAudioToFile(name string, duration time.Duration) {
 	}()
 
 	err = sound.RecordWAV(file, stopCh)
-	failIff(err, "an error occured recording WAV file")
+	failIff(err, "an error occurred recording WAV file")
 	failIff(file.Sync(), "error syncing temp file")
 }

--- a/cmd/musig/cmd/spec.go
+++ b/cmd/musig/cmd/spec.go
@@ -36,7 +36,7 @@ func genSpectrogram(path string, imgPath string) error {
 	}
 	defer file.Close()
 
-	s := dsp.NewSpectrogrammer(model.DOWNSAMPLERATIO, model.MAXFREQ, model.SAMPLESIZE)
+	s := dsp.NewSpectrogrammer(model.DownsampleRatio, model.MaxFreq, model.SampleSize)
 
 	spec, _, err := s.Spectrogram(file)
 	if err != nil {

--- a/cmd/musig/cmd/spec.go
+++ b/cmd/musig/cmd/spec.go
@@ -36,7 +36,7 @@ func genSpectrogram(path string, imgPath string) error {
 	}
 	defer file.Close()
 
-	s := dsp.NewSpectrogrammer(model.DownsampleRatio, model.MaxFreq, model.SampleSize)
+	s := dsp.NewSpectrogrammer(model.DownsampleRatio, model.MaxFreq, model.SampleSize, true)
 
 	spec, _, err := s.Spectrogram(file)
 	if err != nil {

--- a/internal/pkg/db/bolt.go
+++ b/internal/pkg/db/bolt.go
@@ -68,7 +68,7 @@ func (db *BoltDB) Get(keys []model.EncodedKey) (map[model.EncodedKey][]model.Tab
 		return nil
 	})
 
-	return res, errors.Wrap(err, "an error occured when reading from bolt")
+	return res, errors.Wrap(err, "an error occurred when reading from bolt")
 }
 
 // Set stores the list of (key, value) into the bolt file
@@ -90,7 +90,7 @@ func (db *BoltDB) Set(batch map[model.EncodedKey]model.TableValue) error {
 		return nil
 	})
 
-	return errors.Wrap(err, "an error occured when writing to bolt")
+	return errors.Wrap(err, "an error occurred when writing to bolt")
 }
 
 // GetSongID does a song name => songID lookup in the database
@@ -113,7 +113,7 @@ func (db *BoltDB) GetSongID(name string) (uint32, error) {
 		return fmt.Errorf("could not find id for song name: %s", name)
 	})
 
-	return id, errors.Wrap(err, "an error occured when reading from bolt")
+	return id, errors.Wrap(err, "an error occurred when reading from bolt")
 }
 
 // GetSong does a songID => song name lookup in the database
@@ -133,7 +133,7 @@ func (db *BoltDB) GetSong(songID uint32) (string, error) {
 		return nil
 	})
 
-	return name, errors.Wrap(err, "an error occured when reading from bolt")
+	return name, errors.Wrap(err, "an error occurred when reading from bolt")
 }
 
 // SetSong stores a song name in the database and returns it's song ID
@@ -163,7 +163,7 @@ func (db *BoltDB) SetSong(song string) (uint32, error) {
 		return errors.Wrap(b.Put(rawKey, []byte(song)), "error setting song")
 	})
 
-	return songID, errors.Wrap(err, "an error occured when writing to bolt")
+	return songID, errors.Wrap(err, "an error occurred when writing to bolt")
 }
 
 func itob(s uint32) []byte {

--- a/internal/pkg/fingerprint/fingerprint_test.go
+++ b/internal/pkg/fingerprint/fingerprint_test.go
@@ -28,6 +28,7 @@ func testFingerprintingOnFile(t *testing.T, path string) {
 		model.DownsampleRatio,
 		model.MaxFreq,
 		sampleSize,
+		true,
 	)
 
 	file, err := os.Open(path)

--- a/internal/pkg/fingerprint/fingerprint_test.go
+++ b/internal/pkg/fingerprint/fingerprint_test.go
@@ -22,11 +22,11 @@ func TestFingerprinting440And880(t *testing.T) {
 }
 
 func testFingerprintingOnFile(t *testing.T, path string) {
-	sampleSize := model.SAMPLESIZE
+	sampleSize := model.SampleSize
 
 	s := dsp.NewSpectrogrammer(
-		model.DOWNSAMPLERATIO,
-		model.MAXFREQ,
+		model.DownsampleRatio,
+		model.MaxFreq,
 		sampleSize,
 	)
 

--- a/internal/pkg/fingerprint/simple.go
+++ b/internal/pkg/fingerprint/simple.go
@@ -34,7 +34,7 @@ func (sf *SimpleFingerprinter) Fingerprint(songID uint32, cMap []model.Constella
 	for i := 0; i+sf.lastOffset < length; i++ {
 		anchor := cMap[i]
 		for _, p := range cMap[i+sf.anchorOffset : i+sf.lastOffset] {
-			res[model.NewTableKey(anchor, p).Encode()] = *model.NewTableValue(songID, anchor)
+			res[model.NewAnchorKey(anchor, p).Encode()] = *model.NewTableValue(songID, anchor)
 		}
 	}
 

--- a/internal/pkg/model/model.go
+++ b/internal/pkg/model/model.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 )
 
-// DOWNSAMPLERATIO is the default down sample ratio (4)
-const DOWNSAMPLERATIO = 4
+// DownsampleRatio is the default down sample ratio (4)
+const DownsampleRatio = 4
 
-// SAMPLESIZE is the default sample size (1024)
-const SAMPLESIZE = 1024.0
+// SampleSize is the default sample size (1024)
+const SampleSize = 1024.0
 
-// MAXFREQ is 5kHz
-const MAXFREQ = 5000.0
+// MaxFreq is 5kHz
+const MaxFreq = 5000.0
 
 // ConstellationPoint represents a point in the constellation map (time + frequency)
 type ConstellationPoint struct {

--- a/internal/pkg/model/table.go
+++ b/internal/pkg/model/table.go
@@ -8,7 +8,7 @@ import (
 
 // Used to down size the frequences to a 9 bit ints
 // XXX: we could also use 10.7Hz directly
-const freqStep = MAXFREQ / float64(1<<9)
+const freqStep = MaxFreq / float64(1<<9)
 
 // Used to down size the delta times to 14 bit ints (we use 16s as the max duration)
 const deltaTimeStep = 16 / float64(1<<14)
@@ -16,8 +16,8 @@ const deltaTimeStep = 16 / float64(1<<14)
 // TableValueSize represents the TableValueSize when encoded in bytes
 const TableValueSize = 8
 
-// TableKey represents a table key
-type TableKey struct {
+// AnchorKey represents a anchor key
+type AnchorKey struct {
 	// Frequency of the anchor point for the given point's target zone
 	AnchorFreq float64
 	// Frequency of the given point
@@ -29,9 +29,9 @@ type TableKey struct {
 // EncodedKey represents an encoded key
 type EncodedKey uint32
 
-// NewTableKey creates a new table key from the given anchor and the given point
-func NewTableKey(anchor, point ConstellationPoint) *TableKey {
-	return &TableKey{
+// NewAnchorKey creates a new anchor key from the given anchor and the given point
+func NewAnchorKey(anchor, point ConstellationPoint) *AnchorKey {
+	return &AnchorKey{
 		AnchorFreq: anchor.Freq,
 		PointFreq:  point.Freq,
 		// Use absolute just in case anchor is after the target zone
@@ -47,13 +47,13 @@ func (ek EncodedKey) Bytes() []byte {
 	return bk
 }
 
-// Encode encodes the table key using:
+// Encode encodes the anchor key using:
 // 9 bits for the “frequency of the anchor”: fa
 // 9 bits for the ” frequency of the point”: fp
 // 14 bits for the ”delta time between the anchor and the point”: dt
 // The result is then dt | fa | fp
 // XXX: this only works if frequencies are coded in 9 bits or less (if we used a 1024 samples FFT, it will be the case)
-func (tk *TableKey) Encode() EncodedKey {
+func (tk *AnchorKey) Encode() EncodedKey {
 	// down size params
 	fp := uint32(tk.PointFreq / freqStep)
 	fa := uint32(tk.AnchorFreq / freqStep)

--- a/internal/pkg/pipeline/pipeline.go
+++ b/internal/pkg/pipeline/pipeline.go
@@ -24,7 +24,7 @@ func NewDefaultPipeline(dbFile string) (*Pipeline, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "error connection to database at: %s", dbFile)
 	}
-	s := dsp.NewSpectrogrammer(model.DOWNSAMPLERATIO, model.MAXFREQ, model.SAMPLESIZE)
+	s := dsp.NewSpectrogrammer(model.DownsampleRatio, model.MaxFreq, model.SampleSize)
 	fpr := fingerprint.NewDefaultFingerprinter()
 
 	return &Pipeline{

--- a/internal/pkg/pipeline/pipeline.go
+++ b/internal/pkg/pipeline/pipeline.go
@@ -24,7 +24,7 @@ func NewDefaultPipeline(dbFile string) (*Pipeline, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "error connection to database at: %s", dbFile)
 	}
-	s := dsp.NewSpectrogrammer(model.DownsampleRatio, model.MaxFreq, model.SampleSize)
+	s := dsp.NewSpectrogrammer(model.DownsampleRatio, model.MaxFreq, model.SampleSize, true)
 	fpr := fingerprint.NewDefaultFingerprinter()
 
 	return &Pipeline{

--- a/internal/pkg/sound/wav.go
+++ b/internal/pkg/sound/wav.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/gordonklaus/portaudio"
 	"github.com/pkg/errors"
-	riff "github.com/youpy/go-riff"
-	wav "github.com/youpy/go-wav"
+	"github.com/youpy/go-riff"
+	"github.com/youpy/go-wav"
 )
 
 var _ Reader = &WAVReader{}

--- a/pkg/dsp/dsp_test.go
+++ b/pkg/dsp/dsp_test.go
@@ -58,26 +58,26 @@ func TestReshape(t *testing.T) {
 	}{
 		{[]float64{}, 1, [][]float64{}},
 		{[]float64{1, 2, 3}, 1, [][]float64{
-			[]float64{1},
-			[]float64{2},
-			[]float64{3},
+			{1},
+			{2},
+			{3},
 		}},
 		{[]float64{1, 2, 3}, 2, [][]float64{
-			[]float64{1, 2},
+			{1, 2},
 		}},
 		{[]float64{1, 2, 3, 4, 5, 6, 7}, 3, [][]float64{
-			[]float64{1, 2, 3},
-			[]float64{4, 5, 6},
+			{1, 2, 3},
+			{4, 5, 6},
 		}},
 		{[]float64{1, 2, 3, 4, 5, 6, 7, 8}, 4, [][]float64{
-			[]float64{1, 2, 3, 4},
-			[]float64{5, 6, 7, 8},
+			{1, 2, 3, 4},
+			{5, 6, 7, 8},
 		}},
 		{[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, [][]float64{
-			[]float64{1, 2},
-			[]float64{3, 4},
-			[]float64{5, 6},
-			[]float64{7, 8},
+			{1, 2},
+			{3, 4},
+			{5, 6},
+			{7, 8},
 		}},
 	} {
 		require.EqualValues(t, tc.expected, Reshape(tc.input, tc.size), fmt.Sprintf("test %d", i+1))

--- a/pkg/dsp/score.go
+++ b/pkg/dsp/score.go
@@ -1,0 +1,22 @@
+package dsp
+
+import (
+	"github.com/sfluor/musig/internal/pkg/model"
+	"github.com/sfluor/musig/pkg/stats"
+)
+
+// MatchScore computes a match score between the two transformed audio samples (into a list of Key + TableValue)
+func MatchScore(sample, match map[model.EncodedKey]model.TableValue) float64 {
+	// Will hold a list of points (time in the sample sound file, time in the matched database sound file)
+	points := [2][]float64{}
+	matches := 0.0
+	for k, sampleValue := range sample {
+		if matchValue, ok := match[k]; ok {
+			points[0] = append(points[0], float64(sampleValue.AnchorTimeMs))
+			points[1] = append(points[1], float64(matchValue.AnchorTimeMs))
+			matches++
+		}
+	}
+	corr := stats.Correlation(points[0], points[1])
+	return corr * corr * matches
+}

--- a/pkg/dsp/spectrogram.go
+++ b/pkg/dsp/spectrogram.go
@@ -18,16 +18,19 @@ type Spectrogrammer struct {
 	// thresholdCoefficient is used to filter out the important frequencies
 	// increasing it decreases the size of the constellation maps returned
 	thresholdCoefficient float64
+	// windowing is used to activate / deactivate the windowing function
+	windowing bool
 }
 
 // NewSpectrogrammer creates a new spectrogrammer
-func NewSpectrogrammer(dsRatio, maxFreq, binSize float64) *Spectrogrammer {
+func NewSpectrogrammer(dsRatio, maxFreq, binSize float64, windowing bool) *Spectrogrammer {
 	return &Spectrogrammer{
 		dsRatio: dsRatio,
 		maxFreq: maxFreq,
 		binSize: binSize,
 		// TODO stop hardcoding this
 		thresholdCoefficient: 1,
+		windowing: windowing,
 	}
 }
 
@@ -65,7 +68,9 @@ func (s *Spectrogrammer) Spectrogram(file *os.File) ([][]float64, float64, error
 			lp.Filter(bin[:n]),
 			int(s.dsRatio),
 		)
-		ApplyWindow(sampled, HammingWindow)
+		if s.windowing {
+			ApplyWindow(sampled, HammingWindow)
+		}
 		fft := FFT(sampled)
 
 		// TODO remove slicing here when removing duplicate values returned by the FFT

--- a/pkg/dsp/spectrogram.go
+++ b/pkg/dsp/spectrogram.go
@@ -34,7 +34,7 @@ func NewSpectrogrammer(dsRatio, maxFreq, binSize float64) *Spectrogrammer {
 // Spectrogram reads the provided audio file and returns a spectrogram for it
 // Matrix is in the following format:
 // TIME : FREQUENCY : Value
-// time is t * binSize * dsp.DOWNSAMPLERATIO / reader.SampleRate()
+// time is t * binSize * dsp.DownsampleRatio / reader.SampleRate()
 // frequency is f * freqBinSize
 func (s *Spectrogrammer) Spectrogram(file *os.File) ([][]float64, float64, error) {
 	reader, err := sound.NewWAVReader(file)

--- a/pkg/dsp/spectrogram_test.go
+++ b/pkg/dsp/spectrogram_test.go
@@ -15,11 +15,11 @@ import (
 const AssetsDir = "../../assets/test"
 
 func TestSpectrogram440(t *testing.T) {
-	sampleSize := model.SAMPLESIZE
+	sampleSize := model.SampleSize
 
 	s := NewSpectrogrammer(
-		model.DOWNSAMPLERATIO,
-		model.MAXFREQ,
+		model.DownsampleRatio,
+		model.MaxFreq,
 		sampleSize,
 	)
 
@@ -34,7 +34,7 @@ func TestSpectrogram440(t *testing.T) {
 
 	// Threshold to remove frequencies we don't want
 	threshold := 0.5
-	freqBinSize := spr / model.DOWNSAMPLERATIO / sampleSize
+	freqBinSize := spr / model.DownsampleRatio / sampleSize
 
 	checkFreq := func(f, time, ampl float64) {
 		require.InDeltaf(
@@ -54,7 +54,7 @@ func TestSpectrogram440(t *testing.T) {
 			spec[time][f] = math.Abs(spec[time][f]) * invMax
 			if spec[time][f] > threshold {
 				// Check that the frequency of the current point is within [440 - binSize, 440 + bin Size]
-				checkFreq(float64(f)*freqBinSize, float64(time)*model.DOWNSAMPLERATIO/spr, spec[time][f])
+				checkFreq(float64(f)*freqBinSize, float64(time)*model.DownsampleRatio/spr, spec[time][f])
 			}
 		}
 	}
@@ -69,11 +69,11 @@ func TestSpectrogram440(t *testing.T) {
 }
 
 func TestSpectrogram440And880(t *testing.T) {
-	sampleSize := model.SAMPLESIZE
+	sampleSize := model.SampleSize
 
 	s := NewSpectrogrammer(
-		model.DOWNSAMPLERATIO,
-		model.MAXFREQ,
+		model.DownsampleRatio,
+		model.MaxFreq,
 		sampleSize,
 	)
 
@@ -88,7 +88,7 @@ func TestSpectrogram440And880(t *testing.T) {
 
 	// Threshold to remove frequencies we don't want
 	threshold := 0.5
-	freqBinSize := spr / model.DOWNSAMPLERATIO / sampleSize
+	freqBinSize := spr / model.DownsampleRatio / sampleSize
 
 	checkFreq := func(freq, time, ampl float64) {
 		// Check that the frequency of the current point is within [440 - binSize, 440 + bin Size]
@@ -110,7 +110,7 @@ func TestSpectrogram440And880(t *testing.T) {
 			spec[time][f] = math.Abs(spec[time][f]) * invMax
 			if spec[time][f] > threshold {
 				freq := float64(f) * freqBinSize
-				checkFreq(freq, float64(time)*model.DOWNSAMPLERATIO/spr, spec[time][f])
+				checkFreq(freq, float64(time)*model.DownsampleRatio/spr, spec[time][f])
 			}
 		}
 	}

--- a/pkg/dsp/spectrogram_test.go
+++ b/pkg/dsp/spectrogram_test.go
@@ -21,6 +21,8 @@ func TestSpectrogram440(t *testing.T) {
 		model.DownsampleRatio,
 		model.MaxFreq,
 		sampleSize,
+		// No windowing for tests since we want to verify that frequency are in the correct range
+		false,
 	)
 
 	file, err := os.Open(path.Join(AssetsDir, "440.wav"))
@@ -75,6 +77,8 @@ func TestSpectrogram440And880(t *testing.T) {
 		model.DownsampleRatio,
 		model.MaxFreq,
 		sampleSize,
+		// No windowing for tests since we want to verify that frequency are in the correct range
+		false,
 	)
 
 	file, err := os.Open(path.Join(AssetsDir, "440_880.wav"))

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -19,8 +19,8 @@ func Correlation(x []float64, y []float64) float64 {
 		dx := xp - meanX
 		dy := y[i] - meanY
 
-		sX +=  dx * dx
-		sY +=  dy * dy
+		sX += dx * dx
+		sY += dy * dy
 
 		sXY += dx * dy
 	}

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -1,7 +1,6 @@
 package stats
 
 import (
-	"fmt"
 	"math"
 )
 
@@ -24,7 +23,6 @@ func Correlation(x []float64, y []float64) float64 {
 
 		sXY += dx * dy
 	}
-	fmt.Printf("sx: %f, sy: %f, sxy: %f\n", sX, sY, sXY)
 
 	return sXY / (math.Sqrt(sX) * math.Sqrt(sY))
 }
@@ -62,7 +60,7 @@ func Avg(arr []float64) float64 {
 
 // ArgAbove returns the indices for the values from the array that are above the given threshold
 func ArgAbove(threshold float64, arr []float64) []int {
-	res := []int{}
+	var res []int
 	for idx, v := range arr {
 		if v > threshold {
 			res = append(res, idx)

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -1,6 +1,33 @@
 package stats
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
+
+// Correlation computes the correlation between 2 series of points
+// the length used is x's
+func Correlation(x []float64, y []float64) float64 {
+	n := len(x)
+	meanX, meanY := Avg(x[:n]), Avg(y[:n])
+
+	sXY := 0.0
+	sX := 0.0
+	sY := 0.0
+
+	for i, xp := range x {
+		dx := xp - meanX
+		dy := y[i] - meanY
+
+		sX +=  dx * dx
+		sY +=  dy * dy
+
+		sXY += dx * dy
+	}
+	fmt.Printf("sx: %f, sy: %f, sxy: %f\n", sX, sY, sXY)
+
+	return sXY / (math.Sqrt(sX) * math.Sqrt(sY))
+}
 
 // AbsMax returns max(|x| for x in arr)
 func AbsMax(arr []float64) float64 {

--- a/pkg/stats/stats_test.go
+++ b/pkg/stats/stats_test.go
@@ -75,7 +75,7 @@ func TestArgAbove(t *testing.T) {
 		{
 			[]float64{-100, 101},
 			101.1,
-			[]int{},
+			nil,
 		},
 		{
 			[]float64{-100, 100, 50},


### PR DESCRIPTION
This is to improve the matching process, it's very similar to what is described in the shazam paper, illustrations are from the shazam paper:

A matching sample will look like:
![image](https://user-images.githubusercontent.com/24794538/67638965-b5582800-f8ea-11e9-911c-f5b6d4312e08.png)

Whereas a non-matching sample will look like: 
![image](https://user-images.githubusercontent.com/24794538/67638974-d15bc980-f8ea-11e9-9b06-1e3218d72c33.png)

